### PR TITLE
add type and relation information for referrers in node view

### DIFF
--- a/src/app/nodes/node.html
+++ b/src/app/nodes/node.html
@@ -44,7 +44,6 @@
             <small ng-if="!node.code && !node.uri">-</small>
         </div>
 
-
         <thl-node-properties node="node"></thl-node-properties>
 
         <thl-node-references node="node"></thl-node-references>

--- a/src/app/nodes/referrers/referrers.html
+++ b/src/app/nodes/referrers/referrers.html
@@ -4,13 +4,14 @@
 
     <dl class="text-muted">
         <dt>{{'referrers' | translate | capitalize}}</dt>
-        <dd>
-            <div ng-repeat="(k, rs) in node.referrers">
+        <dd ng-repeat="(k, rs) in node.referrers">
+            <div>
                 <div ng-repeat="r in rs">
                     <a ng-href="#/graphs/{{r.type.graph.id}}/types/{{r.type.id}}/nodes/{{r.id}}" title="{{r.uri}} {{r.code}}">
                         &larr;
                         {{r.properties.prefLabel | localizeValue:('unnamed' | translate)}}
                     </a>
+                    | {{typesById[r.type.id].properties.prefLabel | localizeValue}} ({{referenceAttributesByTypeAndId[r.type.id][k].properties.prefLabel | localizeValue}})
                 </div>
             </div>
         </dd>

--- a/src/app/nodes/referrers/referrers.js
+++ b/src/app/nodes/referrers/referrers.js
@@ -3,7 +3,7 @@
 
   angular.module('termed.nodes.referrers', ['pascalprecht.translate', 'termed.rest'])
 
-  .directive('thlNodeReferrers', function($translate, NodeReferrerList) {
+  .directive('thlNodeReferrers', function($translate, NodeReferrerList, TypeList) {
     return {
       restrict: 'E',
       scope: {
@@ -14,6 +14,22 @@
         $scope.lang = $translate.use();
 
         $scope.node.$promise.then(function(node) {
+
+          $scope.typesById = {};
+          $scope.referenceAttributesByTypeAndId = {};
+
+          $scope.types = TypeList.query({
+            graphId: node.type.graph.id
+          }, function(types) {
+            types.forEach(function(c) {
+              $scope.typesById[c.id] = c;
+              $scope.referenceAttributesByTypeAndId[c.id] = {};
+              c.referenceAttributes.forEach(function(r) {
+                $scope.referenceAttributesByTypeAndId[c.id][r.id]=r;
+              });
+            });
+          });
+
           for ( var attrId in node.referrers) {
             node.referrers[attrId] = NodeReferrerList.query({
               graphId: node.type.graph.id,


### PR DESCRIPTION
Add information about the type and relation of referrers in the node view. Group the referrers by attribute (id).

Before:
![image](https://user-images.githubusercontent.com/767995/66046665-e84b0e00-e52e-11e9-982c-e3e46bdf5d04.png)


After:
![image](https://user-images.githubusercontent.com/767995/66046500-8f7b7580-e52e-11e9-88cb-154e7d38da4f.png)


