### PR TITLE
TERMED-257: Updated editing workflow and field order for Code and URI…

### DIFF
--- a/src/app/common/translations.js
+++ b/src/app/common/translations.js
@@ -128,7 +128,13 @@ angular.module('termed.translations', ['pascalprecht.translate', 'ngSanitize'])
     translationButtonCheckCSV: 'Tarkista CSV',
     translationButtonSendCSV: 'Lähetä CSV',
     translationIdOrGraphIdMissing: 'Id tai graafin id puuttuu',
-    translationCsvSendOK: 'CSV käännöstiedoston tuonti -toiminto suoritettu!'
+    translationCsvSendOK: 'CSV käännöstiedoston tuonti -toiminto suoritettu!',
+    warnEditCodeUri: '<b>Koodi</b>- tai <b>URI</b>-tietokenttiä ei tule muokata ilman erityistä syytä. Oletko varma, että haluat muokata tietokentän sisältöä? Muokkaaminen voi vaikuttaa sanastoaineiston lataus- tai tuontikäsittelyihin.',
+    warnRevertCodeUri: 'Haluatko peruuttaa tekemäsi muutokset ja palauttaa <b>Koodi</b>- tai <b>URI</b>-tietokentässä olleen alkuperäisen sisällön? Paina Kyllä-painiketta.<br>Haluatko jatkaa ja tallentaa tekemäsi muutokset? Paina Ei-painiketta.',
+    allowEditCodeUri: 'Salli Koodin ja URI:n muokkaus',
+    warning: "varoitus",
+    yes: "kyllä",
+    no: "ei",
   })
 
   .translations('en', {
@@ -250,7 +256,13 @@ angular.module('termed.translations', ['pascalprecht.translate', 'ngSanitize'])
     translationButtonCheckCSV: 'Check CSV',
     translationButtonSendCSV: 'Send CSV',
     translationIdOrGraphIdMissing: 'Id or graph id is missing',
-    translationCsvSendOK: 'Sending csv was successful!'
+    translationCsvSendOK: 'Sending csv was successful!',
+    warnEditCodeUri: "<b>Code</b> or <b>URI</b> fields should not be edited without a specific reason. Are you sure you want to edit the field content? Editing may affect vocabulary data loading or import processes.",
+    warnRevertCodeUri: 'Do you want to cancel your changes and restore the original content of the <b>Code</b> or <b>URI</b> field? Press Yes.<br>Do you want to proceed and save your changes? Press No.',
+    allowEditCodeUri: 'Allow editing of Code and URI',
+    warning: "warning",
+    yes: "yes",
+    no: "no",
   });
 
 });

--- a/src/app/graphs/graph-edit.html
+++ b/src/app/graphs/graph-edit.html
@@ -37,14 +37,20 @@
 
 <form role="form">
 
+    <!-- Checkbox with ng-model for editing toggle -->
+    <div class="form-group">
+        <label>{{'allowEditCodeUri' | translate | capitalize}}</label><br>
+        <input type="checkbox" ng-model="checkboxState" ng-change="handleCheckboxToggle()">
+    </div>
+
     <div class="form-group">
         <label>{{'code' | translate | capitalize}}</label>
-        <input type="text" class="form-control" ng-model="graph.code">
+        <input type="text" class="form-control" ng-model="graph.code" ng-readonly="!editEnabled">
     </div>
 
     <div class="form-group">
         <label>URI</label>
-        <input type="text" class="form-control" ng-model="graph.uri">
+        <input type="text" class="form-control" ng-model="graph.uri" ng-readonly="!editEnabled">
     </div>
 
     <thl-graph-properties-edit property-map="graph.properties"></thl-graph-properties-edit>
@@ -405,6 +411,41 @@
     </div>
 </div>
 
+<!-- Popup for Warning -->
+<div class="modal fade" id="editConfirmModal" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">{{'warning' | translate | capitalize}}</h5>
+            </div>
+            <div class="modal-body">
+                <p ng-bind-html="trustedEditWarning"></p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" ng-click="confirmEnableEdit()">{{'yes' | translate | capitalize}}</button>
+                <button type="button" class="btn btn-secondary" ng-click="cancelEnableEdit()">{{'no' | translate | capitalize}}</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Popup for Reset Warning -->
+<div class="modal fade" id="restoreConfirmModal" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">{{'warning' | translate | capitalize}}</h5>
+            </div>
+            <div class="modal-body">
+                <p ng-bind-html="trustedRevertWarning"></p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" ng-click="confirmDisableEdit()">{{'yes' | translate | capitalize}}</button>
+                <button type="button" class="btn btn-secondary" ng-click="cancelDisableEdit()">{{'no' | translate | capitalize}}</button>
+            </div>
+        </div>
+    </div>
+</div>
 
 <hr>
 

--- a/src/app/nodes/node-edit.html
+++ b/src/app/nodes/node-edit.html
@@ -59,17 +59,20 @@
 
 <form role="form">
 
+    <!-- Checkbox with ng-model for editing toggle -->
     <div class="form-group">
-        <label>URI</label>
-
-        <input type="text" class="form-control" ng-model="node.uri">
-        
+        <label>{{'allowEditCodeUri' | translate | capitalize}}</label><br>
+        <input type="checkbox" ng-model="checkboxState" ng-change="handleCheckboxToggle()">
     </div>
 
     <div class="form-group">
         <label>{{'code' | translate | capitalize}}</label>
+        <input type="text" class="form-control" ng-model="node.code" ng-readonly="!editEnabled">
+    </div>
 
-        <input type="text" class="form-control" ng-model="node.code">
+    <div class="form-group">
+        <label>URI</label>
+        <input type="text" class="form-control" ng-model="node.uri" ng-readonly="!editEnabled">
     </div>
 
     <thl-node-properties-edit node="node"></thl-node-properties-edit>
@@ -77,6 +80,42 @@
     <thl-node-references-edit node="node"></thl-node-references-edit>
 
 </form>
+
+<!-- Popup for Warning -->
+<div class="modal fade" id="editConfirmModal" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">{{'warning' | translate | capitalize}}</h5>
+            </div>
+            <div class="modal-body">
+                <p ng-bind-html="trustedEditWarning"></p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" ng-click="confirmEnableEdit()">{{'yes' | translate | capitalize}}</button>
+                <button type="button" class="btn btn-secondary" ng-click="cancelEnableEdit()">{{'no' | translate | capitalize}}</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Popup for Reset Warning -->
+<div class="modal fade" id="restoreConfirmModal" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">{{'warning' | translate | capitalize}}</h5>
+            </div>
+            <div class="modal-body">
+                <p ng-bind-html="trustedRevertWarning"></p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" ng-click="confirmDisableEdit()">{{'yes' | translate | capitalize}}</button>
+                <button type="button" class="btn btn-secondary" ng-click="cancelDisableEdit()">{{'no' | translate | capitalize}}</button>
+            </div>
+        </div>
+    </div>
+</div>
 
 <hr>
 


### PR DESCRIPTION
… fields

Modified the editing process for Code and URI fields during node and vocabulary updates. Users must now explicitly enable editing by selecting a checkbox and confirming a warning popup, ensuring deliberate modifications to these fields.

Additionally, the order of the URI and Code fields in the record editing view has been updated to align with the vocabulary editing view and the CSV field order.